### PR TITLE
Auto detect memory grouping prefixes

### DIFF
--- a/rdbtools/__init__.py
+++ b/rdbtools/__init__.py
@@ -1,10 +1,10 @@
 from rdbtools.parser import RdbCallback, RdbParser, DebugCallback
 from rdbtools.callbacks import JSONCallback, DiffCallback, ProtocolCallback, KeyValsOnlyCallback, KeysOnlyCallback
-from rdbtools.memprofiler import MemoryCallback, PrintAllKeys, StatsAggregator, PrintJustKeys
+from rdbtools.memprofiler import MemoryCallback, PrintAllKeys, StatsAggregator, PrintJustKeys, GroupedPrintAllKeys
 
 __version__ = '0.1.15'
 VERSION = tuple(map(int, __version__.split('.')))
 
 __all__ = [
-    'RdbParser', 'RdbCallback', 'JSONCallback', 'DiffCallback', 'MemoryCallback', 'ProtocolCallback', 'KeyValsOnlyCallback', 'KeysOnlyCallback', 'PrintJustKeys']
+    'RdbParser', 'RdbCallback', 'JSONCallback', 'DiffCallback', 'MemoryCallback', 'ProtocolCallback', 'KeyValsOnlyCallback', 'KeysOnlyCallback', 'PrintJustKeys', 'GroupedPrintAllKeys']
 

--- a/rdbtools/cli/rdb.py
+++ b/rdbtools/cli/rdb.py
@@ -4,6 +4,7 @@ import os
 import sys
 from argparse import ArgumentParser
 from rdbtools import RdbParser, JSONCallback, DiffCallback, MemoryCallback, ProtocolCallback, PrintAllKeys, KeysOnlyCallback, KeyValsOnlyCallback
+from rdbtools import GroupedPrintAllKeys
 from rdbtools.encodehelpers import ESCAPE_CHOICES
 from rdbtools.parser import HAS_PYTHON_LZF as PYTHON_LZF_INSTALLED
 
@@ -36,6 +37,10 @@ Example : %(prog)s --command json -k "user.*" /var/redis/6379/dump.rdb"""
                   help="Limit memory output to keys greater to or equal to this value (in bytes)")
     parser.add_argument("-l", "--largest", dest="largest", default=None,
                   help="Limit memory output to only the top N keys (by size)")
+    parser.add_argument("--group-prefix", dest="group_prefixes", action="append", default=[], metavar="PREFIX=ALIAS",
+                  help="Aggregate memory output for keys beginning with PREFIX under the provided ALIAS")
+    parser.add_argument("--auto-group-prefixes", dest="auto_group_prefixes", action="store_true", default=False,
+                  help="Automatically aggregate memory output by detected key prefixes")
     parser.add_argument("-e", "--escape", dest="escape", choices=ESCAPE_CHOICES,
                   help="Escape strings to encoding: %s (default), %s, %s, or %s." % tuple(ESCAPE_CHOICES))
     expire_group = parser.add_mutually_exclusive_group(required=False)
@@ -70,6 +75,19 @@ Example : %(prog)s --command json -k "user.*" /var/redis/6379/dump.rdb"""
             else:
                 filters['types'].append(x)
 
+    if options.group_prefixes:
+        prefix_map = []
+        for mapping in options.group_prefixes:
+            if '=' not in mapping:
+                raise Exception('Invalid group prefix mapping %s. Expected PREFIX=ALIAS format' % mapping)
+            prefix, alias = mapping.split('=', 1)
+            if not prefix or not alias:
+                raise Exception('Invalid group prefix mapping %s. Expected PREFIX=ALIAS format' % mapping)
+            prefix_map.append((prefix, alias))
+        options.group_prefix_map = prefix_map
+    else:
+        options.group_prefix_map = []
+
     out_file_obj = None
     try:
         if options.output:
@@ -84,8 +102,16 @@ Example : %(prog)s --command json -k "user.*" /var/redis/6379/dump.rdb"""
                 'json': lambda f: JSONCallback(f, string_escape=options.escape),
                 'justkeys': lambda f: KeysOnlyCallback(f, string_escape=options.escape),
                 'justkeyvals': lambda f: KeyValsOnlyCallback(f, string_escape=options.escape),
-                'memory': lambda f: MemoryCallback(PrintAllKeys(f, options.bytes, options.largest),
-                                                   64, string_escape=options.escape),
+                'memory': lambda f: MemoryCallback(
+                    GroupedPrintAllKeys(
+                        f,
+                        options.bytes,
+                        options.largest,
+                        options.group_prefix_map if options.group_prefix_map else None,
+                        auto_detect=options.auto_group_prefixes)
+                    if (options.group_prefix_map or options.auto_group_prefixes) else
+                    PrintAllKeys(f, options.bytes, options.largest),
+                    64, string_escape=options.escape),
                 'protocol': lambda f: ProtocolCallback(f, string_escape=options.escape,
                                                        emit_expire=not options.no_expire,
                                                        amend_expire=options.amend_expire

--- a/rdbtools/memprofiler.py
+++ b/rdbtools/memprofiler.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 import random
 import bisect
 from distutils.version import StrictVersion
+import re
 try:
     import ujson as json
 except:
@@ -94,7 +95,7 @@ class PrintAllKeys(object):
 
         if self._largest is not None:
             self._heap = []
-    
+
     def next_record(self, record) :
         if record.key is None:
             return  # some records are not keys (e.g. dict)
@@ -116,6 +117,123 @@ class PrintAllKeys(object):
             while self._heap:
                 bytes, record = heappop(self._heap)
                 self.next_record(record)
+
+
+class GroupedPrintAllKeys(object):
+    MIXED_VALUE = 'mixed'
+    _DELIMITERS = (':', '|', '/', '\\', '.', '-')
+
+    def __init__(self, out, bytes, largest, prefix_map=None, auto_detect=False):
+        self._out = out
+        self._bytes_threshold = int(bytes) if bytes is not None else None
+        self._largest = int(largest) if largest is not None else None
+        # Ensure deterministic behaviour when multiple prefixes could match the same key by
+        # preserving declaration order and preferring the longest prefix.
+        self._prefix_map = list(prefix_map) if prefix_map else []
+        self._auto_detect = bool(auto_detect)
+        headers = "%s,%s,%s,%s,%s,%s,%s,%s\n" % (
+            "database", "type", "key", "size_in_bytes", "encoding", "num_elements", "len_largest_element", "expiry")
+        self._out.write(codecs.encode(headers, 'latin-1'))
+        self._records = {}
+        self._order = []
+        self._auto_aliases = {}
+
+    def _match_alias(self, key):
+        longest = -1
+        alias = None
+        for prefix, name in self._prefix_map:
+            if key.startswith(prefix) and len(prefix) > longest:
+                longest = len(prefix)
+                alias = name
+        if alias is not None:
+            return alias, 'manual'
+        if not self._auto_detect:
+            return None, None
+        prefix = self._auto_prefix(key)
+        if prefix is None:
+            return None, None
+        if prefix not in self._auto_aliases:
+            self._auto_aliases[prefix] = self._format_auto_alias(prefix)
+        return self._auto_aliases[prefix], 'auto'
+
+    def _auto_prefix(self, key):
+        if not key:
+            return None
+        for delimiter in self._DELIMITERS:
+            index = key.find(delimiter)
+            if index > 0:
+                return key[:index]
+        match = re.match(r'^([A-Za-z]+)(?=\d)', key)
+        if match:
+            return match.group(1)
+        return None
+
+    def _format_auto_alias(self, prefix):
+        return f"{prefix}:*"
+
+    def next_record(self, record):
+        if record.key is None:
+            return
+
+        alias, alias_source = self._match_alias(record.key)
+        if alias is not None:
+            group_key = ('group', alias_source, record.database, alias)
+            key_name = alias
+            expiry = ''
+            grouped = True
+        else:
+            group_key = ('key', record.database, record.key)
+            key_name = record.key
+            expiry = record.expiry.isoformat() if record.expiry else ''
+            grouped = False
+
+        if group_key not in self._records:
+            self._order.append(group_key)
+            self._records[group_key] = {
+                'database': record.database,
+                'type': record.type,
+                'key': key_name,
+                'bytes': record.bytes or 0,
+                'encoding': record.encoding,
+                'size': record.size or 0,
+                'len_largest_element': record.len_largest_element or 0,
+                'expiry': expiry,
+                'grouped': grouped
+            }
+            return
+
+        data = self._records[group_key]
+        data['bytes'] += record.bytes or 0
+        data['size'] += record.size or 0
+        data['len_largest_element'] = max(data['len_largest_element'], record.len_largest_element or 0)
+        if data['type'] != record.type:
+            data['type'] = self.MIXED_VALUE
+        if data['encoding'] != record.encoding:
+            data['encoding'] = self.MIXED_VALUE
+
+    def _filtered_records(self):
+        for key in self._order:
+            data = self._records[key]
+            if self._bytes_threshold is None or data['bytes'] >= self._bytes_threshold:
+                yield data
+
+    def end_rdb(self):
+        records = list(self._filtered_records())
+        if self._largest is not None:
+            records = nlargest(self._largest, records, key=lambda item: item['bytes'])
+
+        for data in records:
+            rec_str = "%d,%s,%s,%d,%s,%d,%d,%s\n" % (
+                data['database'],
+                data['type'],
+                data['key'],
+                data['bytes'],
+                data['encoding'],
+                data['size'],
+                data['len_largest_element'],
+                data['expiry']
+            )
+            self._out.write(codecs.encode(rec_str, 'latin-1'))
 
 class PrintJustKeys(object):
     def __init__(self, out):

--- a/tests/memprofiler_tests.py
+++ b/tests/memprofiler_tests.py
@@ -8,7 +8,7 @@ from rdbtools import RdbParser
 from rdbtools import MemoryCallback
 
 
-from rdbtools.memprofiler import MemoryRecord, PrintAllKeys
+from rdbtools.memprofiler import MemoryRecord, PrintAllKeys, GroupedPrintAllKeys
 
 CSV_WITH_EXPIRY = """database,type,key,size_in_bytes,encoding,num_elements,len_largest_element,expiry
 0,string,expires_ms_precision,128,string,27,27,2022-12-25T10:11:12.573000
@@ -50,9 +50,14 @@ def get_sums(file_name):
     parser.parse(os.path.join(os.path.dirname(__file__), 'dumps', file_name))
     return stats.sums
 
-def get_csv(dump_file_name):
+def get_csv(dump_file_name, prefix_map=None, auto_group=False):
     buff = BytesIO()
-    callback = MemoryCallback(PrintAllKeys(buff, None, None), 64)
+    if prefix_map or auto_group:
+        mapped = list(prefix_map.items()) if prefix_map else None
+        stream = GroupedPrintAllKeys(buff, None, None, mapped, auto_detect=auto_group)
+    else:
+        stream = PrintAllKeys(buff, None, None)
+    callback = MemoryCallback(stream, 64)
     parser = RdbParser(callback)
     parser.parse(os.path.join(os.path.dirname(__file__), 
                     'dumps', dump_file_name))
@@ -74,6 +79,38 @@ class MemoryCallbackTestCase(unittest.TestCase):
     def test_csv_with_module(self):
         csv = get_csv('redis_40_with_module.rdb')
         self.assertEquals(csv, CSV_WITH_MODULE)
+
+    def test_grouped_csv(self):
+        csv = get_csv('parser_filters.rdb', auto_group=True)
+        lines = csv.strip().split('\n')
+        self.assertEqual(lines[0], "database,type,key,size_in_bytes,encoding,num_elements,len_largest_element,expiry")
+        prefix_rows = {
+            row.split(',')[2]: row.split(',')
+            for row in lines[1:]
+            if row.split(',')[2].endswith(':*')
+        }
+        self.assertIn('l:*', prefix_rows)
+        lists = prefix_rows['l:*']
+        self.assertEqual(lists[0], '0')
+        self.assertEqual(lists[1], 'list')
+        self.assertEqual(int(lists[3]), 2464)
+        self.assertEqual(lists[4], 'quicklist')
+        self.assertEqual(int(lists[5]), 33)
+        self.assertEqual(int(lists[6]), 578)
+
+    def test_grouped_csv_manual_alias(self):
+        csv = get_csv('parser_filters.rdb', prefix_map={'l': 'lists'})
+        lines = csv.strip().split('\n')
+        grouped = [line for line in lines[1:] if ',lists,' in line]
+        self.assertEqual(len(grouped), 1)
+        cols = grouped[0].split(',')
+        self.assertEqual(cols[0], '0')
+        self.assertEqual(cols[1], 'list')
+        self.assertEqual(cols[2], 'lists')
+        self.assertEqual(int(cols[3]), 2464)
+        self.assertEqual(cols[4], 'quicklist')
+        self.assertEqual(int(cols[5]), 33)
+        self.assertEqual(int(cols[6]), 578)
 
     def test_expiry(self):
         stats = get_stats('keys_with_expiry.rdb')


### PR DESCRIPTION
## Summary
- add a CLI flag to auto-group memory stats by detected key prefixes
- enhance GroupedPrintAllKeys to infer prefixes and label aggregated rows while keeping manual aliases supported
- expand memprofiler tests to cover automatic prefix grouping alongside manual aliasing

## Testing
- python -m unittest tests.memprofiler_tests

------
https://chatgpt.com/codex/tasks/task_e_68da600e7e9c8324a0f3ddb567d3bfd7